### PR TITLE
Mark realitylapse as defunct

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Plugin scrapers for:
 	 - ~~MangaBaby.com~~ (Defunct?)
 	 - ~~MangaTraders~~ (Defunct)
 	 - ~~Fufufuu.net~~ (Defunct)
-	 - Realitylapse.com (Planned, possibly)
+	 - ~~Realitylapse.com~~ (Defunct)
 
 
 Under consideration:   


### PR DESCRIPTION
http://realitylapse.com/ has been down since forever and (iirc) they never really update at all...