### PR TITLE
Update install-dependencies and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ postgres=# CREATE DATABASE mangacms;
 CREATE DATABASE
 postgres=# GRANT ALL PRIVILEGES ON DATABASE mangacms to mangacmsuser;
 GRANT
-CREATE EXTENSION citext;
+postgres=# CREATE EXTENSION citext;
+CREATE EXTENSION
+postgres=# \q
 
 ```
 

--- a/setuptools/installDeps.sh
+++ b/setuptools/installDeps.sh
@@ -11,7 +11,7 @@ if [ $EUID -ne 0 ]; then
 fi
 
 # install said up-to-date python
-apt-get install -y python3.4 python3-dev build-essential postgresql-client postgresql-common libpq-dev postgresql-9.5 unrar
+apt-get install -y python3 python3-dev build-essential postgresql-client postgresql-common libpq-dev postgresql-9.5 unrar
 apt-get install -y postgresql-server-dev-9.5 postgresql-contrib libyaml-dev git phantomjs libffi-dev
 
 # PIL/Pillow support stuff

--- a/setuptools/installDeps.sh
+++ b/setuptools/installDeps.sh
@@ -11,11 +11,11 @@ if [ $EUID -ne 0 ]; then
 fi
 
 # install said up-to-date python
-apt-get install -y python3.4 python3.4-dev build-essential postgresql-client postgresql-common libpq-dev postgresql-9.5 unrar
+apt-get install -y python3.4 python3-dev build-essential postgresql-client postgresql-common libpq-dev postgresql-9.5 unrar
 apt-get install -y postgresql-server-dev-9.5 postgresql-contrib libyaml-dev git phantomjs libffi-dev
 
 # PIL/Pillow support stuff
-sudo apt-get install -y libtiff4-dev libjpeg-turbo8-dev zlib1g-dev liblcms2-dev libwebp-dev libxml2 libxslt1-dev
+sudo apt-get install -y libtiff5-dev libjpeg-turbo8-dev zlib1g-dev liblcms2-dev libwebp-dev libxml2 libxslt1-dev
 
 # Install Numpy/Scipy support packages. Yes, scipy depends on FORTAN. Arrrgh
 sudo apt-get install -y gfortran libopenblas-dev liblapack-dev
@@ -48,6 +48,7 @@ sudo pip3 install --upgrade pyinotify python-dateutil apscheduler rarfile python
 sudo pip3 install --upgrade babel cython irc psycopg2 python-levenshtein chardet roman
 sudo pip3 install --upgrade python-sql natsort pyyaml pillow rpyc server_reloader selenium
 sudo pip3 install --upgrade logging_tree ftfy paramiko irc sqlalchemy
+sudo pip3 install --upgrade pysocks statsd pyexecjs
 
 # numpy and scipy are just needed for the image deduplication stuff. They can be left out if
 # those functions are not desired.
@@ -63,3 +64,5 @@ sudo pip3 install git+https://github.com/bear/parsedatetime
 sudo pip3 install --upgrade pylzma markdown
 
 sudo pip3 install git+https://github.com/fake-name/UniversalArchiveInterface.git
+
+echo "done"


### PR DESCRIPTION
I'm not sure if Python 3.4 is strictly required or if 3.5 is ok. It looks like 3.5.2 is the default for `python3` in Linux Mint right now.

---

```
j@j-pc ~ $ apt search libtiff5-dev
i   libtiff5-dev                    - Tag Image File Format library (TIFF), deve
p   libtiff5-dev:i386               - Tag Image File Format library (TIFF), deve
j@j-pc ~ $ apt search libtiff4-dev
j@j-pc ~ $ apt search python3.4-dev
i A libpython3.4-dev                - Header files and a static library for Pyth
p   libpython3.4-dev:i386           - Header files and a static library for Pyth
i   python3.4-dev                   - Header files and a static library for Pyth
p   python3.4-dev:i386              - Header files and a static library for Pyth
v   python3.4-dev:any               -  
```

I was getting pkg not found exception during `apt install` until I added the repository for python3.4-dev. But I just switched to python3-dev since I think `python3 get-pip.py` (line 41) will default to using Python3.5 anyways.

---

There's also line 101 in `./DbBase.py`

That might need to become 

`				host = settings.DATABASE_IP,`

?

---

edit, side note:

I'm getting `ValueError: Download path /home/j/Downloads/MangaCMS/MP/ does not exist?`
Is there a reason we can't use `os.makedirs(directory)` for each of the file paths in the settings.py?